### PR TITLE
fix: module resolution in JS files

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
+    "moduleResolution": "node",
     "jsx": "preserve",
     "baseUrl": "./",
     "paths": {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.

https://guides.github.com/features/mastering-markdown/

-->

### What does it do

Previously, modules were not being resolved properly by the IDE. This PR fixes that.

### Usage

Try to import any module, IntelliSense should resolve the module and suggest it.

### Why is it needed

Prevent developer from importing the mistyping module names.
